### PR TITLE
fix: Handle annual global nightlights for 2012-2021 period

### DIFF
--- a/povertymapping/nightlights.py
+++ b/povertymapping/nightlights.py
@@ -267,13 +267,13 @@ def make_url(year,
               version=EOG_PRODUCT_VERSION.VER21,
               product=EOG_PRODUCT.ANNUAL,
               coverage=EOG_COVERAGE.GLOBAL,
+              process_suffix = 'c202205302300',
+              vcmcfg = 'vcmslcfg'
              ):
     year_suffix = ''
     if type(year) != str:
         year = str(year)
         
-    vcmcfg = 'vcmslcfg'
-    process_suffix = 'c202205302300'
     if product == 'annual' and version == 'v21':
         if int(year) < 2012 or int(year) > 2021:
             raise ValueError(f'No {product} {version} EOG data for {year}')
@@ -301,16 +301,6 @@ def make_url(year,
     return url
     
 
-# def make_url(
-#     year,
-#     viirs_data_type="average",
-#     ntlights_base_url="https://eogdata.mines.edu/nighttime_light",
-#     version="v21",
-#     product="annual",
-#     coverage="global",
-# ):
-#     url_format = f"{ntlights_base_url}/{product}/{version}/{year}/VNL_{version}_npp_{year}_{coverage}_vcmslcfg_c202205302300.{viirs_data_type}.dat.tif.gz"
-#     return url_format
 
 
 def make_clip_hash(
@@ -320,6 +310,9 @@ def make_clip_hash(
     version=EOG_PRODUCT_VERSION.VER21,
     product=EOG_PRODUCT.ANNUAL,
     coverage=EOG_COVERAGE.GLOBAL,
+    process_suffix = 'c202205302300',
+    vcmcfg = 'vcmslcfg'
+
 ):
     # Generate hash from aoi, type_, and year, which will act as a hash key for the cache
     data_tuple = (
@@ -329,6 +322,8 @@ def make_clip_hash(
         version,
         product,
         coverage,
+        process_suffix,
+        vcmcfg
     )
     m = hashlib.md5()
     for item in data_tuple:
@@ -346,6 +341,9 @@ def generate_clipped_raster(
     product=EOG_PRODUCT.ANNUAL,
     coverage=EOG_COVERAGE.GLOBAL,
     cache_dir=NIGHTLIGHTS_CACHE_DIR,
+    process_suffix = 'c202205302300',
+    vcmcfg = 'vcmslcfg'
+
 ):
     viirs_cache_dir = Path(os.path.expanduser(cache_dir)) / "global"
     viirs_cache_dir.mkdir(parents=True, exist_ok=True)
@@ -356,6 +354,8 @@ def generate_clipped_raster(
         version=version,
         product=product,
         coverage=coverage,
+        process_suffix=process_suffix,
+        vcmcfg=vcmcfg
     )
     viirs_zipped_filename = urlclean(viirs_url)
     viirs_unzip_filename = ".".join(viirs_zipped_filename.split(".")[:-1])  # remove .gz
@@ -372,9 +372,9 @@ def generate_clipped_raster(
 
 
 def generate_clipped_metadata(
-    year, bounds, viirs_data_type, version, product, coverage, clip_cache_dir
+    year, bounds, viirs_data_type, version, product, coverage, clip_cache_dir, process_suffix, vcmcfg
 ):
-    key = make_clip_hash(year, bounds, viirs_data_type, version, product, coverage)
+    key = make_clip_hash(year, bounds, viirs_data_type, version, product, coverage, process_suffix, vcmcfg)
     clip_meta_data = dict(
         bounds=np.array2string(bounds),
         year=str(year),
@@ -382,6 +382,8 @@ def generate_clipped_metadata(
         version=version,
         product=product,
         coverage=coverage,
+        process_suffix=process_suffix,
+        vcmcfg=vcmcfg
     )
     clipped_metadata_file = clip_cache_dir / f"{key}.metadata.json"
     logger.info(f"Adding metadata.json file {clipped_metadata_file}")
@@ -397,8 +399,10 @@ def get_clipped_raster(
     product=EOG_PRODUCT.ANNUAL,
     coverage=EOG_COVERAGE.GLOBAL,
     cache_dir=NIGHTLIGHTS_CACHE_DIR,
+    process_suffix = 'c202205302300',
+    vcmcfg = 'vcmslcfg'
 ):
-    key = make_clip_hash(year, bounds, viirs_data_type, version, product, coverage)
+    key = make_clip_hash(year, bounds, viirs_data_type, version, product, coverage, process_suffix, vcmcfg )
     clip_cache_dir = Path(os.path.expanduser(cache_dir)) / "clip"
     clip_cache_dir.mkdir(parents=True, exist_ok=True)
     clipped_file = clip_cache_dir / f"{key}.tif"
@@ -414,9 +418,11 @@ def get_clipped_raster(
         version=version,
         product=product,
         coverage=coverage,
+        process_suffix=process_suffix,
+        vcmcfg=vcmcfg
     )
     generate_clipped_metadata(
-        year, bounds, viirs_data_type, version, product, coverage, clip_cache_dir
+        year, bounds, viirs_data_type, version, product, coverage, clip_cache_dir, process_suffix, vcmcfg
     )
     return clipped_file
 
@@ -429,6 +435,8 @@ def generate_nightlights_feature(
     product=EOG_PRODUCT.ANNUAL,
     coverage=EOG_COVERAGE.GLOBAL,
     cache_dir=NIGHTLIGHTS_CACHE_DIR,
+    process_suffix = 'c202205302300',
+    vcmcfg = 'vcmslcfg',
     extra_args=dict(band_num=1, nodata=-999),
     func=["min", "max", "mean", "median", "std"],
     column="avg_rad",
@@ -442,6 +450,8 @@ def generate_nightlights_feature(
         product=product,
         coverage=coverage,
         cache_dir=cache_dir,
+        process_suffix=process_suffix,
+        vcmcfg=vcmcfg
     )
     if copy:
         aoi = aoi.copy()

--- a/test-notebooks/test_viirs_urls.ipynb
+++ b/test-notebooks/test_viirs_urls.ipynb
@@ -1,0 +1,248 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "0b3c7f01-6522-4d6b-93c6-c4b9412d3a9a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%reload_ext autoreload\n",
+    "%autoreload 2"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "b617b763-7669-4f6a-995b-9eeba67f87f2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from povertymapping.nightlights import *"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "82e3d264-d147-49e3-9c94-c633590ebe42",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "## EOG Programmatic Access\n",
+    "* ntlights metadata:  https://eogdata.mines.edu/products/vnl/\n",
+    "* directory url:  https://eogdata.mines.edu/nighttime_light/annual/v21/\n",
+    "* sample link (size 9.7GB):  https://eogdata.mines.edu/nighttime_light/annual/v21/2014/VNL_v21_npp_2014_global_vcmslcfg_c202205302300.average.dat.tif.gz\n",
+    "* sample mask link (size 267 MB): https://eogdata.mines.edu/nighttime_light/annual/v21/2014/VNL_v21_npp_2014_global_vcmslcfg_c202205302300.average_masked.dat.tif.gz"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "277a2342-5dfb-4215-a25e-c643a8dd4319",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "EXPECTED_URLS = {\n",
+    "    '2012': 'https://eogdata.mines.edu/nighttime_light/annual/v21/2012/VNL_v21_npp_201204-201303_global_vcmcfg_c202205302300.average.dat.tif.gz',\n",
+    "    '2013': 'https://eogdata.mines.edu/nighttime_light/annual/v21/2013/VNL_v21_npp_2013_global_vcmcfg_c202205302300.average.dat.tif.gz',\n",
+    "    '2014': 'https://eogdata.mines.edu/nighttime_light/annual/v21/2014/VNL_v21_npp_2014_global_vcmslcfg_c202205302300.average.dat.tif.gz',\n",
+    "    '2015': 'https://eogdata.mines.edu/nighttime_light/annual/v21/2015/VNL_v21_npp_2015_global_vcmslcfg_c202205302300.average.dat.tif.gz',\n",
+    "    '2016': 'https://eogdata.mines.edu/nighttime_light/annual/v21/2016/VNL_v21_npp_2016_global_vcmslcfg_c202205302300.average.dat.tif.gz',\n",
+    "    '2017': 'https://eogdata.mines.edu/nighttime_light/annual/v21/2017/VNL_v21_npp_2017_global_vcmslcfg_c202205302300.average.dat.tif.gz',\n",
+    "    '2018': 'https://eogdata.mines.edu/nighttime_light/annual/v21/2018/VNL_v21_npp_2018_global_vcmslcfg_c202205302300.average.dat.tif.gz',\n",
+    "    '2019': 'https://eogdata.mines.edu/nighttime_light/annual/v21/2019/VNL_v21_npp_2019_global_vcmslcfg_c202205302300.average.dat.tif.gz',\n",
+    "    '2020': 'https://eogdata.mines.edu/nighttime_light/annual/v21/2020/VNL_v21_npp_2020_global_vcmslcfg_c202205302300.average.dat.tif.gz',\n",
+    "    '2021': 'https://eogdata.mines.edu/nighttime_light/annual/v21/2021/VNL_v21_npp_2021_global_vcmslcfg_c202205302300.average.dat.tif.gz'\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "3b1e3ef2-2be7-4152-a3ca-0deffa397608",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "for year,expected_url in EXPECTED_URLS.items():\n",
+    "    actual_url = make_url(year)\n",
+    "    if actual_url != expected_url:\n",
+    "        print(f'Unmatched URL for  {year}')\n",
+    "        print(f'actual: {actual_url}')\n",
+    "        print(f'expect: {expected_url}')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "50d70875-393b-4f66-b6ec-3c48fda10fcc",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'https://eogdata.mines.edu/nighttime_light/annual/v21/2014/VNL_v21_npp_2014_global_vcmslcfg_c202205302300.cvg.dat.tif.gz'"
+      ]
+     },
+     "execution_count": 11,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "make_url(2014,viirs_data_type=EOG_VIIRS_DATA_TYPE.CVG)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "id": "50bda274-168c-4944-92d3-873df81afbd5",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "namespace(VER21='v21')"
+      ]
+     },
+     "execution_count": 13,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "EOG_PRODUCT_VERSION"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "id": "dd825316-7d45-47f6-a99d-20ea8d50c25b",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "namespace(ANNUAL='annual')"
+      ]
+     },
+     "execution_count": 14,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "EOG_PRODUCT"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "id": "f2ace231-a853-47bf-acba-ce36a9b0889d",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "namespace(AVERAGE='average',\n",
+       "          AVERAGE_MASKED='average_masked',\n",
+       "          CF_CVG='cf_cvg',\n",
+       "          CVG='cvg',\n",
+       "          LIT_MASK='lit_mask',\n",
+       "          MAXIMUM='maximum',\n",
+       "          MEDIAN='median',\n",
+       "          MEDIAN_MASKED='median_masked',\n",
+       "          MINIMUM='minimum')"
+      ]
+     },
+     "execution_count": 15,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "EOG_VIIRS_DATA_TYPE"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "id": "e5f7c1dd-aa1d-4ac8-b98a-f1ab1ef3d9e2",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "namespace(GLOBAL='global')"
+      ]
+     },
+     "execution_count": 17,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "EOG_COVERAGE"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "id": "eec3fdd0-6541-47fd-afe3-04110d22b647",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "\u001b[0;31mSignature:\u001b[0m\n",
+       "\u001b[0mmake_url\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m\u001b[0m\n",
+       "\u001b[0;34m\u001b[0m    \u001b[0myear\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m\u001b[0m\n",
+       "\u001b[0;34m\u001b[0m    \u001b[0mviirs_data_type\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;34m'average'\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m\u001b[0m\n",
+       "\u001b[0;34m\u001b[0m    \u001b[0mntlights_base_url\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;34m'https://eogdata.mines.edu/nighttime_light'\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m\u001b[0m\n",
+       "\u001b[0;34m\u001b[0m    \u001b[0mversion\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;34m'v21'\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m\u001b[0m\n",
+       "\u001b[0;34m\u001b[0m    \u001b[0mproduct\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;34m'annual'\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m\u001b[0m\n",
+       "\u001b[0;34m\u001b[0m    \u001b[0mcoverage\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;34m'global'\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m\u001b[0m\n",
+       "\u001b[0;34m\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+       "\u001b[0;31mDocstring:\u001b[0m <no docstring>\n",
+       "\u001b[0;31mFile:\u001b[0m      ~/work/povmap/unicef-ai4d-poverty-mapping/povertymapping/nightlights.py\n",
+       "\u001b[0;31mType:\u001b[0m      function\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "make_url?"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ab5fa61e-31a0-461c-9a35-606b57358e07",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.13"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
* Handle viirs download for all years with annual data for ver21 (2012-2021)
* Add namespaces to allow enumeration of values for eog options (e.g. viirs_data_type)
* Add test notebook to check computation of url