### PR TITLE
chore: remove title header for quarto rendering

### DIFF
--- a/notebooks/2022-01-17-initial-model-ph-mm-tl-kh/model_kh.ipynb
+++ b/notebooks/2022-01-17-initial-model-ph-mm-tl-kh/model_kh.ipynb
@@ -1,10 +1,15 @@
 {
  "cells": [
   {
-   "cell_type": "markdown",
+   "cell_type": "raw",
    "metadata": {},
    "source": [
-    "# Model Training and Evaluation (Cambodia)"
+    "---\n",
+    "title: Model Training and Evaluation (Cambodia)\n",
+    "format:\n",
+    "  html:\n",
+    "    code-fold: false\n",
+    "---"
    ]
   },
   {
@@ -1289,16 +1294,6 @@
    "metadata": {},
    "source": [
     "## Model Evaluation"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### Evaluation functions\n",
-    "Borrowed from https://colab.research.google.com/drive/1RmQwqyvrk7zpmldtdfKK_e_8oOARLJTE\n",
-    "\n",
-    "**TODO**: Integrate into a model_utils module"
    ]
   },
   {

--- a/notebooks/2022-01-17-initial-model-ph-mm-tl-kh/model_mm.ipynb
+++ b/notebooks/2022-01-17-initial-model-ph-mm-tl-kh/model_mm.ipynb
@@ -1,10 +1,15 @@
 {
  "cells": [
   {
-   "cell_type": "markdown",
+   "cell_type": "raw",
    "metadata": {},
    "source": [
-    "# Model Training and Evaluation (Myanmar)"
+    "---\n",
+    "title: Model Training and Evaluation (Myanmar)\n",
+    "format:\n",
+    "  html:\n",
+    "    code-fold: false\n",
+    "---"
    ]
   },
   {

--- a/notebooks/2022-01-17-initial-model-ph-mm-tl-kh/model_ph.ipynb
+++ b/notebooks/2022-01-17-initial-model-ph-mm-tl-kh/model_ph.ipynb
@@ -13,13 +13,6 @@
    ]
   },
   {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "# Model Training and Evaluation (Philippines)"
-   ]
-  },
-  {
    "cell_type": "code",
    "execution_count": 1,
    "metadata": {},

--- a/notebooks/2022-01-17-initial-model-ph-mm-tl-kh/model_tl.ipynb
+++ b/notebooks/2022-01-17-initial-model-ph-mm-tl-kh/model_tl.ipynb
@@ -1,10 +1,15 @@
 {
  "cells": [
   {
-   "cell_type": "markdown",
+   "cell_type": "raw",
    "metadata": {},
    "source": [
-    "# Model Training and Evaluation (Timor Leste)"
+    "---\n",
+    "title: Model Training and Evaluation (Timor Leste)\n",
+    "format:\n",
+    "  html:\n",
+    "    code-fold: false\n",
+    "---"
    ]
   },
   {
@@ -1427,7 +1432,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.13 | packaged by conda-forge | (main, May 27 2022, 16:58:50) \n[GCC 10.3.0]"
+   "version": "3.9.13"
   },
   "vscode": {
    "interpreter": {


### PR DESCRIPTION
This PR removes the headers for the model_<country>.ipynb notebooks, so that it doesn't get rendered twice by quarto. 