### PR TITLE
Add .gitleaksignore to repo

### DIFF
--- a/.gitleaksignore
+++ b/.gitleaksignore
@@ -1,0 +1,7 @@
+ec92e81a7cb9126b2d99465dcca8de6e18d0a4d1,ec92e81a7cb9126b2d99465dcca8de6e18d0a4d1:notebooks/2022-01-17-initial-model-ph-mm-tl-kh/model_mm.html
+ec92e81a7cb9126b2d99465dcca8de6e18d0a4d1,ec92e81a7cb9126b2d99465dcca8de6e18d0a4d1:notebooks/2022-01-17-initial-model-ph-mm-tl-kh/model_kh.html
+ec92e81a7cb9126b2d99465dcca8de6e18d0a4d1,ec92e81a7cb9126b2d99465dcca8de6e18d0a4d1:notebooks/2022-01-17-initial-model-ph-mm-tl-kh/model_tl.html
+ec92e81a7cb9126b2d99465dcca8de6e18d0a4d1,ec92e81a7cb9126b2d99465dcca8de6e18d0a4d1:notebooks/2022-01-17-initial-model-ph-mm-tl-kh/model_ph.html
+8786ff2f62e84206dd1eab884c64ac06ca746cad:search.json:generic-api-key:21
+8786ff2f62e84206dd1eab884c64ac06ca746cad:search.json:generic-api-key:21
+


### PR DESCRIPTION
This PR adds exceptions to gitleaks by specifying the `.gitleaksignore` file. Over standup, we already determined that these are false positives, so it is okay to ignore these leaks. 