### PR TITLE
Reorder table of contents for Sprint 2

### DIFF
--- a/_quarto.yml
+++ b/_quarto.yml
@@ -24,9 +24,9 @@ website:
       - section: "Sprint 2 (Cross Country Experiments)"
         contents:
           - href: cross-country-report.qmd 
-          - href: notebooks/2023-01-24-dhs-cross-country-experiments/2023-02-06_crosscountry_normalized.ipynb
           - href: notebooks/2023-01-24-dhs-cross-country-experiments/2023-01-24_crosscountry_initial.ipynb
           - href: notebooks/2023-02-01-index-recalculation-experiments/2023-02-06_index_recalculation.ipynb
+          - href: notebooks/2023-01-24-dhs-cross-country-experiments/2023-02-06_crosscountry_normalized.ipynb
 
 
 format:


### PR DESCRIPTION
This PR reorders the table of contents for Sprint 2 so that it follows the order of the experiments (baseline -> pooled wealth index -> scaled).